### PR TITLE
RFC: use sys.exit

### DIFF
--- a/src/dw3t/__main__.py
+++ b/src/dw3t/__main__.py
@@ -1,5 +1,5 @@
+import sys
 from dw3t.main import main
 
 if __name__ == "__main__":
-    exit(main())
-
+    sys.exit(main())


### PR DESCRIPTION
`exit`, despite being available in most Python REPLs, isn't generally available.