### PR TITLE
BLD: migrate build backend from uv-build to flit-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
 dw3t = "dw3t.main:main"
 
 [build-system]
-requires = ["uv_build>=0.9.17,<0.10.0"]
-build-backend = "uv_build"
+requires = ["flit_core >=3.11,<4"]
+build-backend = "flit_core.buildapi"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
I love uv-build, but it's not needed here.