### PR TITLE
DEP: use tomllib on Python 3.15.0a6 and newer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,8 @@ dependencies = [
     "inifix>=6.1.1",
     "nonos>=0.19.1",
     "numpy>=2.4.0",
-    "tomli>=2.4.0",
     "tomli-w>=1.2.0",
+    "tomli>=2.4.0; python_full_version<'3.15.0a6'",
 ]
 
 [project.scripts]

--- a/src/dw3t/main.py
+++ b/src/dw3t/main.py
@@ -2,11 +2,11 @@ import os
 import argparse
 import json
 import importlib
+import sys
 from pathlib import Path
 
 import numpy as np
 
-import tomli
 import tomli_w
 from deep_chainmap import DeepChainMap
 from nonos.api import GasDataSet
@@ -15,6 +15,11 @@ from dw3t.model import load_model, Opacity
 from dw3t._typing import F, FArray2D
 from dw3t._parsing import is_set, list_of_middle_keys
 from dw3t.default import DEFAULT_LAYER, MANDATORY_SET
+
+if sys.hexversion >= 0x30f00a6:
+    import tomllib
+else:
+    import tomli as tomllib
 
 def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
@@ -35,7 +40,7 @@ def main(argv: list[str] | None = None) -> int:
     parser = get_parser()
     args = parser.parse_args(argv)
     with open(args.parameter_file, "rb") as f:
-        config_file_layer = tomli.load(f)
+        config_file_layer = tomllib.load(f)
 
     #TODO: improve handling of mandatory parameters
     # ensures that we do not add mandatory parameters without knowing it

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ dependencies = [
     { name = "inifix" },
     { name = "nonos" },
     { name = "numpy" },
-    { name = "tomli" },
+    { name = "tomli", marker = "python_full_version < '3.15'" },
     { name = "tomli-w" },
 ]
 
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "inifix", specifier = ">=6.1.1" },
     { name = "nonos", specifier = ">=0.19.1" },
     { name = "numpy", specifier = ">=2.4.0" },
-    { name = "tomli", specifier = ">=2.4.0" },
+    { name = "tomli", marker = "python_full_version < '3.15'", specifier = ">=2.4.0" },
     { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 


### PR DESCRIPTION
alpha 6 is out, including an upgraded tomllib with TOML 1.1 support