### PR TITLE
TST: treat warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         include:
         - python-version: 3.11.4
           install-args: --resolution=lowest
+          pytest-args: -Wdefault # don't error on ancient warnings
 
     runs-on: ubuntu-latest
     steps:
@@ -50,7 +51,7 @@ jobs:
       run: uv sync --group dev ${{ matrix.install-args }}
 
     - name: Test
-      run: uv run --no-sync pytest --color=yes
+      run: uv run --no-sync pytest --color=yes ${{ matrix.pytest-args }}
 
   # platform-tests:
   #   strategy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,12 @@ dev = [
     "pytest>=9.0.2",
 ]
 
+[tool.pytest]
+filterwarnings = [
+    "error",
+    "default:unclosed file:ResourceWarning", # https://github.com/birnstiel/dsharp_opac/pull/15
+]
+
 [tool.uv]
 constraint-dependencies = [
     # via astropy


### PR DESCRIPTION
this addresses a defect in the current process:
- #77 upgraded nonos to a version with more warnings
- these warnings were missed in review
- and only painstakenly addressed in #78

the warnings *were* [hit in CI](https://github.com/volodia99/dw3t/actions/runs/23882241877/job/69637707189?pr=77). Treating them as errors makes them much more visible in review.